### PR TITLE
Add Now I Know My ABCD to project list, reformat project names to use h3 formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,43 @@
+
 # NeuroHackademy 2022 projects
 
-## List of projects
-* [Project template](#project-template): Template to use when creating new projects
-* [nsdsocnonsoc](#nsdsocnonsoc)
-* [NSD Memory & Connectivity](#nsdMemConn)
-
-
-### Project template
+## Project template
 When adding a new project to the listing, please copy and paste the template below.
 
-**Name**: [project name]\
+### [project name]
 **Project url(s)**: [link to GitHub repo or other resources]\
 **Contributors**: [list of people involved], [NAME](https://github.com/GITHUBID)\
 **Description of project**: [a few sentences describing the project]\
 **How to get involved**: [optional explanation of how one can get involved in the project]
 
-**Name**: [nsdsocnonsoc]\
+## List of projects
+
+### nsdsocnonsoc
 **Project url(s)**: [https://github.com/neat-one/nsd_biosoc, https://docs.google.com/presentation/d/1PuSvhphsMeWrlqITsHrPIQRBFqoBVEBTPwH9jttzZ54/edit?usp=sharing]\
 **Contributors**: [Marisa Lytle (https://github.com/lytlemn), Erin Neaton (https://github.com/neat-one), Veronica Porubsky (https://github.com/vporubsky), Madison Thomasson (https://github.com/madisonthomasson), Avery Van De Water (https://github.com/avery-water)]\
 **Description of project**: [The goal of the project is to create a predictive model to identify fMRI signals associated with the viewing of social and nonsocial naturalistic images. Stimuli and fMRI data were obtained from the Natural Scenes Dataset (Allen, St-Yves, Wu, Breedlove, Prince, Dowdle, Nau, Caron, Pestilli, Charest, Hutchinson, Naselaris*, & Kay*. A massive 7T fMRI dataset to bridge cognitive neuroscience and artificial intelligence. Nature Neuroscience (2022).)]\
 **How to get involved**: Email avery-vandewater@uiowa.edu
 
-**Name**: NSD Memory and Connectivity<a name="nsdMemConn"></a>\
+### NSD Memory and Connectivity<a name="nsdMemConn"></a>
 **Project url(s)**: [GitHub](https://github.com/mjstarrett/nsdMemConn), [Presentation Slides](https://docs.google.com/presentation/d/1ZOEUpSm1Qk9ObNv7ggyarLrJqXC6BWBmwrWc0-ETBgY/edit?usp=sharing), [Natural Scenes Dataset](https://natural-scenes-dataset.s3.amazonaws.com/index.html) \
 **Contributors**: [Jeanne Barthélemy](https://github.com/Gaerdil), [Rhideeta Jalal](https://github.com/rhijalal), [Jessica Kraft](https://github.com/jessicankraft), [Yutong Li](https://github.com/yutongyutongli), [Zhen-Qi Liu](https://github.com/liuzhenqi77), [Jacqueline Quirke](https://github.com/dequirkepalatis), [Kirsten Rhittershofer](https://github.com/KirstenRittershofer), [Karen Shen](https://github.com/KarenShen21), [Mike Starrett Ambrose](https://github.com/mjstarrett), [Haley Wang](https://github.com/Haley-R-Wang) \
 **Description of project**: Our project aims to explore the cognitive and neural mechanisms underlying encoding and recognition (familiarity) memory processes. To this end, we have begun analzying data from the Natural Scenes Dataset (NSD). We aim to analyze behavioral performance using signal detection approaches to characterize memory function and associated effects on reaction times. We are also conducting task-based analyses including functional connectivity (using resting state to test our framework) and multivariate classification using linear support vector machines and convolutional neural networks. ROIs of interest include hippocampus, retrosplenial cortex, and whole brain data.\
 **How to get involved**: To-date, we have used a branching workflow. You may access the public GitHub repository (listed above), clone it, contribute and initiate a pull request to merge your changes into the main analysis pipeline.  
 
-**Name**: fsub-extractor\
+### fsub-extractor
 **Project url(s)**: [Github Repo](https://github.com/smeisler/fsub-extractor)\
 **Contributors**: [Steven Meisler](https://github.com/smeisler), [Emily Kubota](https://github.com/emilykubota), [Chenying Zhao](https://github.com/zhao-cy), [Alicja Olszewska](https://gitub.com/alice-in-coderland), [Hamsi Radhakrishnan](https://github.com/hamsiradhakrishnan), [Brad Caron](https://github.com/bacaron), [Drew Winters](https://github.com/drewwint), [Daniela Cossio](https://github.com/dcossio), [McKenzie Paige Hagen](https://github.com/mckenziephagen), [Tashrif Billah](https://github.com/tashrifbillah)\
 **Description of project**: Software that functionally segments white matter connections to generate task-specific subcomponents of fiber bundles.\
 **How to get involved**: Post an issue or submit a PR. 
 
-**Name**: Ni-ght-MARE\
+### Ni-ght-MARE
 **Project url(s)**: [Github Repo](https://github.com/PTDZ/Ni-ght-MARE)\
 **Contributors**: [Patrycja Dzianok](https://github.com/PTDZ)\
 **Description of project**: A step-by-step pipeline for using NiMARE Python package for neuroimaging meta-analysis. The project shows functionality of NiMARE and sample (basic/undergoing) meta-analysis results of fMRI studies regarding dementia. Additionally, during the Neurohackademy I created a list ([SORTED](https://github.com/PTDZ/SORTED)) of interesting neuroscience ideas, tools and links (the idea was born out of Slack discussions with other participants) that will (hopefully) be updated on an ongoing basis and can serve neuroscience community (especially MSc/PhD students and postdocs).\
-**How to get involved**: Post an issue or submit a PR. 
+**How to get involved**: Post an issue or submit a PR.
+
+### Now I Know My ABCD
+**Project url(s)**: [Repo](https://github.com/now-i-know-my-abcd/docs) with discussion boards; [website](https://now-i-know-my-abcd.github.io/docs/)\
+**Contributors**: [Team](https://github.com/now-i-know-my-abcd): Sana Ali, Clare McCann, Monica Thieu, Lucy Whitmore\
+**Description of project**: A resource hub for [ABCD](https://abcdstudy.org/scientists/) researchers filled with frequently asked questions, code troubleshooting, archived Slack or related message board threads from past workshops, and associated tweets.\
+**How to get involved**: Submit a pull request! 🙏


### PR DESCRIPTION
I tried to do this yesterday, but I must have messed it up somehow! Just saw this morning that my old PR was nowhere to be seen in the history of main pull requests.

Re: the proposed project name formatting change: [As of spring 2021,](https://github.blog/changelog/2021-04-13-table-of-contents-support-in-markdown-files/) Github provides a button to access an automatic table of contents for README Markdown files, which generates headings based on Markdown headers in the document.

![https://github.com/isaacs/github/issues/215#issuecomment-807688648](https://user-images.githubusercontent.com/29888641/112554719-18dbd300-8dc7-11eb-92a9-5840590fc1c2.png)

Accordingly, this PR removes the bullet-point manual ToC (which indeed it looks like people are forgetting to update!) and changes the project template to format the project name as an h3 header. On my patch branch, it does look like it's working in the auto ToC!
